### PR TITLE
WIP: Added basic config mixing and moved component object creation to SC

### DIFF
--- a/src/assets/structure.json
+++ b/src/assets/structure.json
@@ -1,22 +1,20 @@
 [
   {
-    "Button": {
-      "config": {},
+      "key": "Button",
+      "config": [{
+        "type": "text",
+        "value": "Hello from config!"
+      }],
       "children": {
-        "Example": "example"
+        "name": "Example"
       }
-    }
-  },
-  {
-    "Title": {
-      "config": {},
+  }, {
+      "key" : "Title",
+      "config": [],
+      "children": {}
+  }, {
+      "key" : "NonExistent",
+      "config": [],
       "children": {}
     }
-  },
-  {
-    "NonExistent": {
-      "config": {},
-      "children": {}
-    }
-  }
 ]

--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <button>Test button</button>
+    <button>{{ config }}</button>
   </div>
 </template>
 
@@ -8,7 +8,14 @@
 import Vue from 'vue';
 export default Vue.extend({
   name: 'Button',
-  props: ['structure'],
+  props: {
+    childStructure: {
+      type: Object
+    },
+    config: {
+      type: Object
+    }
+  }
 });
 </script>
 

--- a/src/render/RenderComponent.vue
+++ b/src/render/RenderComponent.vue
@@ -1,10 +1,8 @@
 <template>
   <div>
-    <component v-for="(element, index) in elements"
-               :is="element"
-               :key="elementNames[index]"
-               :name="elementNames[index]"
-               :structure="elementChildren[index]"
+    <component v-for="element in elements"
+               :is="element.component"
+               :key="element.key"
                ></component>
   </div>
 </template>
@@ -26,17 +24,8 @@ export default Vue.extend({
     },
   },
   computed: {
-    elementNames(): string[] {
-      return this.structure.map(
-        (item: VuesualComponent) => Object.keys(item)[0],
-      );
-    },
-    elementChildren(): VuesualComponent[] {
-      return this.structure.map(
-        (item: VuesualComponent) => item[Object.keys(item)[0]]['children'],
-      );
-    },
-    elements(): ImportComponentFunction[] {
+    // todo: make it as one type
+    elements(): { component: ImportComponentFunction, key: string }[] {
       return this.structure.map((item: VuesualComponent) =>
         toElementComponent(item),
       );

--- a/src/render/RenderComponent.vue
+++ b/src/render/RenderComponent.vue
@@ -25,7 +25,7 @@ export default Vue.extend({
   },
   computed: {
     // todo: make it as one type
-    elements(): { component: ImportComponentFunction, key: string }[] {
+    elements(): Array<{ component: ImportComponentFunction; key: string }> {
       return this.structure.map((item: VuesualComponent) =>
         toElementComponent(item),
       );

--- a/src/services/structureConverter.ts
+++ b/src/services/structureConverter.ts
@@ -17,38 +17,40 @@ interface AsyncComponent {
 export type ImportComponentFunction = () => AsyncComponent;
 
 // to-do: add proper typings
-const mixConfiguration = function (component: any, configuartion: any): Component {
+const mixConfiguration = (component: any, configuration: any): Component => {
   // to-do make it less retarded
-  let configProp = {
+  const configProp = {
     config: {
-      default: configuartion
-    }
-  }
-  component.default.options.props = {...component.default.options.props, ...configProp}
-  return component
-}
+      default: configuration,
+    },
+  };
+  component.default.options.props = {
+    ...component.default.options.props,
+    ...configProp,
+  };
+  return component;
+};
 
-const buildConfiguarbleComponent = async (
-  vuesualComponent: VuesualComponent
+const buildConfigurableComponent = async (
+  vuesualComponent: VuesualComponent,
 ): Promise<Component> => {
   return new Promise((resolve, reject) => {
-    import(`@/components/${vuesualComponent.key}.vue`)
-      .then(component => {
-        mixConfiguration(component, vuesualComponent.config)
-        resolve(component)
-      })
-  })
+    import(`@/components/${vuesualComponent.key}.vue`).then(component => {
+      mixConfiguration(component, vuesualComponent.config);
+      resolve(component);
+    });
+  });
 };
 
 export const toElementComponent = (
   structure: VuesualComponent,
-): { component: ImportComponentFunction, key: string } => {
-  return { 
+): { component: ImportComponentFunction; key: string } => {
+  return {
     component: () => ({
-    component: buildConfiguarbleComponent(structure),
-    error: Error,
-    timeout: 200,
-  }),
-  key: structure.key
-}
+      component: buildConfigurableComponent(structure),
+      error: Error,
+      timeout: 200,
+    }),
+    key: structure.key,
+  };
 };

--- a/src/services/structureConverter.ts
+++ b/src/services/structureConverter.ts
@@ -2,6 +2,7 @@ import VuesualComponent from '@/typings/structure';
 import { Component } from 'vue';
 import Error from '@/components/Error.vue';
 import Vue from 'vue';
+import { rejects } from 'assert';
 
 Vue.config.warnHandler = msg => {
   console.log(msg.substring(msg.indexOf('Cannot'), msg.length - 1));
@@ -15,12 +16,39 @@ interface AsyncComponent {
 
 export type ImportComponentFunction = () => AsyncComponent;
 
+// to-do: add proper typings
+const mixConfiguration = function (component: any, configuartion: any): Component {
+  // to-do make it less retarded
+  let configProp = {
+    config: {
+      default: configuartion
+    }
+  }
+  component.default.options.props = {...component.default.options.props, ...configProp}
+  return component
+}
+
+const buildConfiguarbleComponent = async (
+  vuesualComponent: VuesualComponent
+): Promise<Component> => {
+  return new Promise((resolve, reject) => {
+    import(`@/components/${vuesualComponent.key}.vue`)
+      .then(component => {
+        mixConfiguration(component, vuesualComponent.config)
+        resolve(component)
+      })
+  })
+};
+
 export const toElementComponent = (
   structure: VuesualComponent,
-): ImportComponentFunction => {
-  return () => ({
-    component: import(`@/components/${Object.keys(structure)[0]}.vue`),
+): { component: ImportComponentFunction, key: string } => {
+  return { 
+    component: () => ({
+    component: buildConfiguarbleComponent(structure),
     error: Error,
     timeout: 200,
-  });
+  }),
+  key: structure.key
+}
 };

--- a/src/typings/structure.ts
+++ b/src/typings/structure.ts
@@ -1,6 +1,5 @@
 export default interface VuesualComponent {
-  [key: string]: {
+    key: string,
     config: {};
     children: {};
-  };
 }

--- a/src/typings/structure.ts
+++ b/src/typings/structure.ts
@@ -1,5 +1,5 @@
 export default interface VuesualComponent {
-    key: string,
-    config: {};
-    children: {};
+  key: string;
+  config: {};
+  children: {};
 }


### PR DESCRIPTION
* moved all component object related logic to SC service which allowed to ommit additional loops and keep everything related to creating component from JSON file in one place
* changed JSON structure of the component obj to avoid `Object.keys()` iterations
* added basic mechanism of mixing a config into props

The main goal of moving everything to SC service was to keep all component-related work in one place. Now `render-component` is responsible only for... well rendering components ^^. i also wanted to make component instance more editable before instantiation.

I'll probably add the child structure in a same way. Currently it's WIP so please comment only on idea and don't comment the code. It's extremely bad right now and needs refactoring. Probably i can make it much simplier and tweak performance a little bit.